### PR TITLE
feat: Ignore extensions for markdown files

### DIFF
--- a/app/libs/posts/generate-post.mjs
+++ b/app/libs/posts/generate-post.mjs
@@ -54,7 +54,11 @@ function generatePost() {
         const date = new Date().toISOString().slice(0, 10).replace(/-/g, "/");
         filename = `generated-post-${date.replace(/\//g, "-")}.mdx`;
       } else {
-        filename = `${inputPath}.mdx`;
+        if (!inputPath.endsWith(".mdx") || !inputPath.endsWith(".md")) {
+          filename = `${inputPath}.mdx`;
+        } else {
+          filename = inputPath;
+        }
       }
       writePost(title, description, filename);
     });


### PR DESCRIPTION
## Summary

When the user gave a file name with 1 file extension,
the cli command generates a file path with 2 file extensions.
This Pull-Request aims to prevent auto-generated file extensions from duplication.

## Example of Diff

```diff
  $ filename: filename.mdx
- > filename.mdx.mdx 
+ > filename.mdx 
```
